### PR TITLE
Fix typo in error message

### DIFF
--- a/src/parse.c
+++ b/src/parse.c
@@ -358,7 +358,7 @@ AstNode *parseProgram(Token *p_head, int length) {
   for (int i = 0; i < length - 1; i++) p_curr = p_curr->p_next;
   
   if(p_curr->type != TOK_END) {
-    printf("Syntax Error @ Line %i: Missing start token.\n", p_curr->lineNumber);
+    printf("Syntax Error @ Line %i: Missing end token.\n", p_curr->lineNumber);
     exit(0);
   }
 


### PR DESCRIPTION
It looks like there's a typo in the last printf statement. The if condition checks for a missing end token, but the error warns about the start token.  Btw, the language is really cool and your project is really impressive!